### PR TITLE
Allow program to work without flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ echo "EOF"
 $ export URL="https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
 
 # Experience pleasure by using the catslack!
-$ ./myCoolTestScript.sh | catslack -url $URL
+$ ./myCoolTestScript.sh | catslack
 ```

--- a/main.go
+++ b/main.go
@@ -55,6 +55,9 @@ func init() {
 
 	// Parse all flags
 	flag.Parse()
+	if slackURL == "" {
+		slackURL = os.Getenv("URL")
+	}
 }
 
 func main() {


### PR DESCRIPTION
If env var $URL is set, there is no need for the -url.
-url will override $URL if set.